### PR TITLE
Improve layout responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,21 +7,29 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <h1>Iowa Gambling Task</h1>
-    <p>Choose a deck to draw a card and see if you can maximize your profit!</p>
-    
-    <div id="decks">
-        <button onclick="drawCard('A')">Deck A</button>
-        <button onclick="drawCard('B')">Deck B</button>
-        <button onclick="drawCard('C')">Deck C</button>
-        <button onclick="drawCard('D')">Deck D</button>
-    </div>
+    <main class="container">
+        <header class="page-header">
+            <h1>Iowa Gambling Task</h1>
+            <p class="subtitle">Choose a deck to draw a card and see if you can maximize your profit!</p>
+        </header>
 
-    <p id="immediateResult">You <span id="resultValue"></span></p> <!-- Element to display the immediate result -->
-    
-    <p id="message">Total Profit: $<span id="profit">2000</span></p>
-    <button onclick="downloadCSV()">Download Results (CSV)</button>
-    <button onclick="saveResults(generateStringRandomly(), computeNetScores())">Save Results to Server</button>
+        <section id="decks" aria-label="Card decks">
+            <button onclick="drawCard('A')">Deck A</button>
+            <button onclick="drawCard('B')">Deck B</button>
+            <button onclick="drawCard('C')">Deck C</button>
+            <button onclick="drawCard('D')">Deck D</button>
+        </section>
+
+        <section class="results" aria-live="polite">
+            <p id="immediateResult">You <span id="resultValue"></span></p>
+            <p id="message">Total Profit: $<span id="profit">2000</span></p>
+        </section>
+
+        <div class="actions">
+            <button onclick="downloadCSV()">Download Results (CSV)</button>
+            <button onclick="saveResults(generateStringRandomly(), computeNetScores())">Save Results to Server</button>
+        </div>
+    </main>
 
     <script src="script.js"></script>
 

--- a/styles.css
+++ b/styles.css
@@ -1,29 +1,105 @@
+* {
+    box-sizing: border-box;
+}
+
 body {
     font-family: Arial, sans-serif;
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: linear-gradient(180deg, #f7f8fb 0%, #eef1f6 100%);
+    color: #1f2933;
+}
+
+.container {
+    width: min(100%, 960px);
+    margin: 0 auto;
+    padding: 3rem clamp(1.5rem, 4vw, 3rem);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.5rem, 4vw, 3rem);
+}
+
+.page-header {
     text-align: center;
-    padding: 50px;
+}
+
+.page-header h1 {
+    font-size: clamp(2rem, 4vw, 3.25rem);
+    margin-bottom: 0.5rem;
+}
+
+.subtitle {
+    font-size: clamp(1rem, 2.5vw, 1.25rem);
+    color: #52606d;
+    margin: 0;
+}
+
+#decks {
+    display: grid;
+    gap: clamp(0.75rem, 3vw, 1.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
 button {
-    padding: 10px 20px;
-    margin: 10px;
-    font-size: 20px;
+    padding: clamp(0.75rem, 2.5vw, 1rem);
+    font-size: clamp(1rem, 2.5vw, 1.25rem);
+    border: none;
+    border-radius: 12px;
+    background-color: #2563eb;
+    color: #ffffff;
+    box-shadow: 0 10px 25px rgba(37, 99, 235, 0.25);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+    cursor: pointer;
 }
 
-#message {
-    font-size: 24px;
-    margin-top: 30px;
+button:hover,
+button:focus {
+    outline: none;
+    transform: translateY(-2px);
+    background-color: #1d4ed8;
+    box-shadow: 0 12px 30px rgba(29, 78, 216, 0.35);
 }
 
+.results {
+    text-align: center;
+    display: grid;
+    gap: 0.75rem;
+}
+
+#message,
 #immediateResult {
-    font-size: 24px;
-    margin-top: 30px;
+    font-size: clamp(1.25rem, 3vw, 1.75rem);
+    margin: 0;
+}
+
+.actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: clamp(0.75rem, 3vw, 1.5rem);
+}
+
+.actions button {
+    flex: 1 1 220px;
 }
 
 .gain {
-    color: green;
+    color: #0f9d58;
 }
 
 .loss {
-    color: red;
+    color: #d93025;
+}
+
+@media (max-width: 600px) {
+    body {
+        align-items: flex-start;
+    }
+
+    .container {
+        padding-block: clamp(2rem, 8vw, 3rem);
+    }
 }


### PR DESCRIPTION
## Summary
- restructure the main layout markup with semantic sections and action groups
- refresh the stylesheet with responsive typography, grid-based deck layout, and flexible button rows
- add mobile-friendly spacing adjustments to ensure comfortable viewing on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5b1d75cbc832682b2e20f052d0315