### PR TITLE
Add Monte Carlo craps profit simulator (Pass/Come/Odds/Place 6&8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,40 @@ npm install
 npm start
 ```
 Then open `http://localhost:3000` in your browser.
+
+
+## Craps Monte Carlo Simulation
+`craps_monte_carlo.js` estimates expected profit for the following strategy on a $5 minimum table:
+
+- Pass Line: $5
+- Come: $5 (keep one active come cycle)
+- Odds: 3-4-5x (Las Vegas Strip style)
+  - 4/10: 3x
+  - 5/9: 4x
+  - 6/8: 5x
+- Place 6: $5
+- Place 8: $5
+
+Assumptions in the simulation:
+- Place 6/8 are working only when the point is ON.
+- Come bet is OFF on the come-out roll.
+- Profit is tracked per shooter (from first come-out until seven-out).
+
+Run:
+
+```bash
+node craps_monte_carlo.js 1000000
+```
+
+Example output:
+
+```json
+{
+  "numShooters": 300000,
+  "totalProfit": -612557.5000000854,
+  "totalRolls": 2556102,
+  "averageProfitPerShooter": -2.041858333333618,
+  "averageProfitPerRoll": -0.23964517065441263,
+  "averageProfitPer100Rolls": -23.964517065441264
+}
+```

--- a/craps_monte_carlo.js
+++ b/craps_monte_carlo.js
@@ -1,0 +1,101 @@
+function rollDice() { return 1 + Math.floor(Math.random() * 6) + 1 + Math.floor(Math.random() * 6); }
+
+const MIN = 5;
+const PASS = MIN;
+const COME = MIN;
+const PLACE6 = MIN;
+const PLACE8 = MIN;
+
+const maxOdds = (p) => (p === 4 || p === 10 ? 3 : p === 5 || p === 9 ? 4 : 5);
+const oddsWin = (p, b) => (p === 4 || p === 10 ? 2 * b : p === 5 || p === 9 ? 1.5 * b : 1.2 * b);
+
+function simulateShooter() {
+  let profit = 0;
+  let rolls = 0;
+
+  let tablePoint = null;
+  let passPoint = null;
+  let passOdds = 0;
+
+  let comePoint = null;
+  let comeOdds = 0;
+
+  while (true) {
+    const d = rollDice();
+    rolls += 1;
+
+    if (tablePoint === null) {
+      profit -= PASS;
+      if (d === 7 || d === 11) {
+        profit += 2 * PASS;
+      } else if (d === 2 || d === 3 || d === 12) {
+        // lose pass
+      } else {
+        tablePoint = d;
+        passPoint = d;
+        passOdds = PASS * maxOdds(d);
+        profit -= passOdds;
+      }
+      continue;
+    }
+
+    // resolve existing line/come/place bets on point-on roll
+    if (d === 7) {
+      profit -= PLACE6 + PLACE8;
+      break;
+    }
+
+    if (d === passPoint) {
+      profit += 2 * PASS;
+      profit += passOdds + oddsWin(passPoint, passOdds);
+      tablePoint = null;
+      passPoint = null;
+      passOdds = 0;
+    }
+
+    if (comePoint !== null && d === comePoint) {
+      profit += 2 * COME;
+      profit += comeOdds + oddsWin(comePoint, comeOdds);
+      comePoint = null;
+      comeOdds = 0;
+    }
+
+    if (d === 6) profit += PLACE6 * (7 / 6);
+    if (d === 8) profit += PLACE8 * (7 / 6);
+
+    // place a fresh come bet each point-on roll when no established come point
+    if (tablePoint !== null && comePoint === null) {
+      profit -= COME;
+      if (d === 7 || d === 11) {
+        profit += 2 * COME;
+      } else if (d === 2 || d === 3 || d === 12) {
+        // lose come
+      } else {
+        comePoint = d;
+        comeOdds = COME * maxOdds(d);
+        profit -= comeOdds;
+      }
+    }
+  }
+
+  return { profit, rolls };
+}
+
+function simulate(n) {
+  let p = 0, r = 0;
+  for (let i = 0; i < n; i++) {
+    const s = simulateShooter();
+    p += s.profit; r += s.rolls;
+  }
+  return {
+    numShooters: n,
+    totalProfit: p,
+    totalRolls: r,
+    averageProfitPerShooter: p / n,
+    averageProfitPerRoll: p / r,
+    averageProfitPer100Rolls: (p / r) * 100,
+  };
+}
+
+const n = Number(process.argv[2] || 1000000);
+console.log(JSON.stringify(simulate(n), null, 2));


### PR DESCRIPTION
### Motivation
- Provide a quick, reproducible Monte Carlo estimator for expected profit under a common craps strategy (Pass Line, Come, 3-4-5x odds, Place 6 & 8) on a $5 minimum table. 
- Capture shooter-level profit from come-out through seven-out so players/researchers can evaluate the long-run expectation of this combined bet set.

### Description
- Add `craps_monte_carlo.js`, a Node.js Monte Carlo simulator that implements Pass Line ($5), Come ($5), Las Vegas Strip 3-4-5x odds, and $5 Place bets on 6 and 8, tracking profit per shooter and per roll. 
- The simulator applies assumptions that Place 6/8 only pay when the point is ON and the Come bet is off on the come-out roll, and it deducts/credits flat and odds bets appropriately. 
- Update `README.md` with a new "Craps Monte Carlo Simulation" section that documents assumptions, usage (`node craps_monte_carlo.js 1000000`), and example output.

### Testing
- Ran the simulator with `node craps_monte_carlo.js 300000`, which executed successfully and produced JSON summary output (example: `"totalProfit": -623389.9999999953`, `"averageProfitPerShooter": -2.077966666666651`, `"averageProfitPer100Rolls": -24.402588892376958`).
- Re-ran `node craps_monte_carlo.js 300000` during development to verify behavior and observed consistent successful runs (other example output observed: `"totalProfit": -612557.5000000854`, `"averageProfitPerShooter": -2.041858333333618`).
- Verified that the new file `craps_monte_carlo.js` and `README.md` changes were written without runtime errors during the test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f9c7450483268613af5e88706fef)